### PR TITLE
✨기능 추가: Payment 조회시 발생하는 긴 지연시간 해결

### DIFF
--- a/LearnsMate/build.gradle
+++ b/LearnsMate/build.gradle
@@ -84,6 +84,10 @@ dependencies {
     dependencies {
         implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
     }
+    // Redis에 데이터를 저장할 때, LocalDateTime 타입을 제대로 직렬화(serialize) 도움 라이브러리
+    dependencies {
+        implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    }
 }
 
 tasks.named('test') {

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/member/controller/MemberController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/member/controller/MemberController.java
@@ -37,8 +37,12 @@ public class MemberController {
     public ResponseEntity<MemberPageResponse<ResponseFindMemberVO>> findAllStudent(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "50") int size) {
+        log.info("findAllStudent 시작");
+        long startTime = System.currentTimeMillis(); // 시작 시간
         MemberPageResponse<ResponseFindMemberVO> response = memberFacade.findAllMemberByMemberType(page, size, MemberType.STUDENT);
-
+        long endTime = System.currentTimeMillis(); // 종료 시간
+        log.info("findAllStudent 끝");
+        log.info("findAllStudent 종료 | 실행 시간: {} ms", (endTime - startTime));
         return ResponseEntity.ok(response);
     }
 
@@ -49,8 +53,13 @@ public class MemberController {
             @RequestParam(defaultValue = "15") int size,
             @RequestParam(required = false, defaultValue = "memberCode") String sortField,
             @RequestParam(required = false, defaultValue = "DESC") String sortDirection) {
+        long startTime = System.currentTimeMillis(); // 시작 시간
+        log.info("findAllStudentBySort 시작");
         MemberPageResponse<ResponseFindMemberVO> response
                 = memberFacade.findAllMemberByMemberTypeBySort(page, size, MemberType.STUDENT, sortField, sortDirection);
+        long endTime = System.currentTimeMillis(); // 종료 시간
+        log.info("findAllStudentBySort 끝");
+        log.info("findAllStudentBySort 종료 | 실행 시간: {} ms", (endTime - startTime));
 
         return ResponseEntity.ok(response);
     }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/payment/domain/dto/PaymentMonthlyRevenueDTO.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/payment/domain/dto/PaymentMonthlyRevenueDTO.java
@@ -2,9 +2,11 @@ package intbyte4.learnsmate.payment.domain.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class PaymentMonthlyRevenueDTO {
     private int year;
     private int month;

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/payment/domain/vo/PaymentPageResponse.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/payment/domain/vo/PaymentPageResponse.java
@@ -2,11 +2,13 @@ package intbyte4.learnsmate.payment.domain.vo;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class PaymentPageResponse<T, G> {
     private List<T> paymentData;
     private G graphData;

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/payment/repository/CustomPaymentRepository.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/payment/repository/CustomPaymentRepository.java
@@ -1,5 +1,6 @@
 package intbyte4.learnsmate.payment.repository;
 
+import intbyte4.learnsmate.payment.domain.dto.PaymentDetailDTO;
 import intbyte4.learnsmate.payment.domain.dto.PaymentFilterDTO;
 import intbyte4.learnsmate.payment.domain.entity.Payment;
 import intbyte4.learnsmate.payment.domain.vo.PaymentFilterRequestVO;
@@ -12,6 +13,8 @@ public interface CustomPaymentRepository {
 
     // 필터링x 정렬o
     Page<Payment> findAllWithSort(Pageable pageable);
+
+    Page<PaymentDetailDTO> findAllWithSort2(Pageable pageable);
 
     // 필터링o 정렬o
     Page<PaymentFilterDTO> findPaymentByFiltersWithSort(PaymentFilterRequestVO request, Pageable pageable);

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/payment/service/PaymentFacade.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/payment/service/PaymentFacade.java
@@ -26,8 +26,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -45,6 +47,7 @@ public class PaymentFacade {
     private final PaymentRepository paymentRepository;
     private final IssueCouponService issueCouponService;
     private final PaymentMapper paymentMapper;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     public PaymentPageResponse<ResponseFindPaymentVO, Map<Integer, List<PaymentMonthlyRevenueDTO>>> getPaymentsWithGraph(int page, int size) {
         Page<Payment> payments = getPaymentsWithPagination(page, size);
@@ -64,18 +67,31 @@ public class PaymentFacade {
     // Facade
     public PaymentPageResponse<ResponseFindPaymentVO, Map<Integer, List<PaymentMonthlyRevenueDTO>>> getPaymentsWithGraphAndSort(
             int page, int size, String sortField, String sortDirection) {
-        log.info("getPaymentsWithPaginationAndSort 시작");
-        long startTime = System.currentTimeMillis(); // 시작 시간
-//        Page<Payment> payments = getPaymentsWithPaginationAndSort(page, size, sortField, sortDirection);
-        long endTime = System.currentTimeMillis(); // 종료 시간
-        log.info("getPaymentsWithPaginationAndSort 종료 | 실행 시간: {} ms", (endTime - startTime));
 
+        String redisKey = "payments:page=" + page + ":size=" + size + ":sort=" + sortField + "_" + sortDirection;
+
+        log.info("🔍 Redis에서 캐시 확인: {}", redisKey);
+        long startTime = System.currentTimeMillis();
+
+        // *️⃣ Redis에서 데이터 조회 (캐시 확인)
+        PaymentPageResponse<ResponseFindPaymentVO, Map<Integer, List<PaymentMonthlyRevenueDTO>>> cachedData =
+                (PaymentPageResponse<ResponseFindPaymentVO, Map<Integer, List<PaymentMonthlyRevenueDTO>>>) redisTemplate.opsForValue().get(redisKey);
+
+        if (cachedData != null) {
+            log.info("✅ Redis 캐시 HIT! 캐싱된 데이터 반환");
+            long endTime = System.currentTimeMillis();
+            log.info("🕒 캐시 데이터 조회 시간: {} ms", (endTime - startTime));
+            return cachedData;
+        }
+
+        log.info("🚨 Redis 캐시 MISS! DB에서 조회 시작");
+
+        // 2️⃣ 기존 데이터 조회 로직
         log.info("getPaymentsWithPaginationAndSort2 시작");
         startTime = System.currentTimeMillis();
         Page<PaymentDetailDTO> paymentDetailDTOs = getPaymentsWithPaginationAndSort2(page, size, sortField, sortDirection);
-        endTime = System.currentTimeMillis();
+        long endTime = System.currentTimeMillis();
         log.info("getPaymentsWithPaginationAndSort2 종료 | 실행 시간: {} ms", (endTime - startTime));
-        log.info("paymentDetailDTOs: {}", paymentDetailDTOs.getContent());
 
         log.info("getMonthlyRevenueComparisonWithSort 시작");
         Map<Integer, List<PaymentMonthlyRevenueDTO>> graphData = (page == 0) ? getMonthlyRevenueComparisonWithSort() : null;
@@ -84,16 +100,20 @@ public class PaymentFacade {
         List<ResponseFindPaymentVO> paymentVOs = paymentDetailDTOs.stream()
                 .map(paymentMapper::fromDtoToResponseVO)
                 .collect(Collectors.toList());
-//        List<ResponseFindPaymentVO> paymentVOs = payments.stream()
-//                .map(this::getPaymentDetailDTO)
-//                .map(paymentMapper::fromDtoToResponseVO)
-//                .collect(Collectors.toList());
 
         boolean hasNext = paymentDetailDTOs.hasNext();
         long totalElements = paymentDetailDTOs.getTotalElements();
 
-        return new PaymentPageResponse<>(paymentVOs, graphData, hasNext, totalElements);
+        // 3️⃣ Redis에 저장 (TTL 30분)
+        PaymentPageResponse<ResponseFindPaymentVO, Map<Integer, List<PaymentMonthlyRevenueDTO>>> response =
+                new PaymentPageResponse<>(paymentVOs, graphData, hasNext, totalElements);
+
+        redisTemplate.opsForValue().set(redisKey, response, Duration.ofMinutes(30));
+        log.info("📌 Redis에 데이터 저장 완료 (TTL: 30분)");
+
+        return response;
     }
+
 
     // 정렬
     private Page<Payment> getPaymentsWithPaginationAndSort(int page, int size, String sortField, String sortDirection) {


### PR DESCRIPTION
- 제목 : ✨기능 추가: Payment 조회시 발생하는 긴 지연시간 해결

## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
1. Lazy Loading으로 인한 N+1 문제 해결
2. fetch join과 DTO를 통한 join으로 불필요한 쿼리문 감소
3. 인덱스 적용으로 인한 빠른 데이터 조회
4. Redis 캐싱을 통한 성능 개선(300ms -> 10ms)

  <br/>

## 이미지 첨부
- 기존의 코드 호출시 걸리던 시간
![image](https://github.com/user-attachments/assets/9b7c710b-574d-4a56-a88b-1a132d7ee16a)
- 서비스 코드 수정 후
![image](https://github.com/user-attachments/assets/ae47b670-1d5f-4233-97d3-5527417fed9d)
- 인덱스 적용 후 
![image](https://github.com/user-attachments/assets/fd290476-2764-442d-911a-99f38b11024b)
- Redis 캐싱 적용 후
![image](https://github.com/user-attachments/assets/a53e67ce-e7e2-4649-9f79-c153ec7b16d6)


<br/>

## 🔧 앞으로의 과제

- 다음 할 일을 적어주세요 (앞으로의 할 일을 작성해도 괜찮습니다)
jmeter로 테스팅
  <br/>
