### PR TITLE
IssueCoupon 대량 발급시 발생하는 속도 저하 문제 개선

### DIFF
--- a/LearnsMate/build.gradle
+++ b/LearnsMate/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     // EC2 인스턴스 헬스 체크를 위한 actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // Redis 통합
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // Redis 연결 풀 관리

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/LearnsMateApplication.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/LearnsMateApplication.java
@@ -2,8 +2,10 @@ package intbyte4.learnsmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class LearnsMateApplication {
 
     public static void main(String[] args) {

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/TokenController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/controller/TokenController.java
@@ -53,7 +53,7 @@ public class TokenController {
             redisService.deleteToken(userCode);
 
             // DBMS에서 토큰 삭제
-            refreshTokenService.deleteRefreshTokenFromDB(userCode);
+//            refreshTokenService.deleteRefreshTokenFromDB(userCode);
 
             // 응답에서 쿠키 제거
             clearCookie(response, "token");

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/EmailService.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/admin/service/EmailService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.Random;
@@ -47,6 +48,7 @@ public class EmailService {
     }
 
     // 캠페인 이메일 발송 메소드 추가
+    @Async
     public void sendCampaignEmail(String email, String campaignTitle, String campaignContents) {
         log.info("Start sending campaign email to: " + email);
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/batch/CampaignIssueCouponProcessor.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/batch/CampaignIssueCouponProcessor.java
@@ -19,9 +19,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 @RequiredArgsConstructor
@@ -46,7 +45,6 @@ public class CampaignIssueCouponProcessor implements ItemProcessor<Pair<MemberDT
                 couponCategoryService::findByCouponCategoryCode
         );
 
-        // 관리자 캐싱
         Admin admin = adminCache.computeIfAbsent(
                 couponDTO.getAdminCode(),
                 code -> {
@@ -57,13 +55,9 @@ public class CampaignIssueCouponProcessor implements ItemProcessor<Pair<MemberDT
 
         Member student = memberMapper.fromMemberDTOtoMember(studentDTO);
         CouponEntity coupon = couponMapper.toAdminCouponEntity(couponDTO, couponCategory, admin);
-
-        IssueCoupon issueCoupon = new IssueCoupon();
-        issueCoupon.setStudent(student);
-        issueCoupon.setCoupon(coupon);
-        issueCoupon.setCouponIssueDate(LocalDateTime.now());
-        issueCoupon.setCouponUseStatus(false);
+        IssueCoupon issueCoupon = IssueCoupon.createIssueCoupon(coupon, student);
 
         return issueCoupon;
     }
+
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/batch/CampaignIssueCouponReader.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/batch/CampaignIssueCouponReader.java
@@ -16,26 +16,41 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class CampaignIssueCouponReader implements ItemReader<Pair<MemberDTO, CouponDTO>> {
-    private List<Pair<MemberDTO, CouponDTO>> studentCouponPairs;
-    private Iterator<Pair<MemberDTO, CouponDTO>> iterator;
+
+    private List<MemberDTO> students;
+    private List<CouponDTO> coupons;
+    private int studentIndex = 0;
+    private int couponIndex = 0;
 
     public void setStudentCouponPairs(List<MemberDTO> students, List<CouponDTO> coupons) {
-        this.studentCouponPairs = new ArrayList<>();
-        for (MemberDTO student : students) {
-            for (CouponDTO coupon : coupons) {
-                studentCouponPairs.add(Pair.of(student, coupon));
-            }
-        }
-        this.iterator = studentCouponPairs.iterator();
+        this.students = students;
+        this.coupons = coupons;
+        this.studentIndex = 0;
+        this.couponIndex = 0;
     }
 
     @Override
     public Pair<MemberDTO, CouponDTO> read() {
-        if (iterator != null && iterator.hasNext()) {
-            return iterator.next();
-        } else {
+        if (students == null || coupons == null || students.isEmpty() || coupons.isEmpty()) {
             return null;
         }
+
+        if (studentIndex >= students.size()) {
+            return null;
+        }
+
+        Pair<MemberDTO, CouponDTO> pair = Pair.of(
+                students.get(studentIndex),
+                coupons.get(couponIndex)
+        );
+
+        couponIndex++;
+
+        if (couponIndex >= coupons.size()) {
+            couponIndex = 0;
+            studentIndex++;
+        }
+
+        return pair;
     }
 }
-

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/batch/CampaignIssueCouponWriter.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/batch/CampaignIssueCouponWriter.java
@@ -1,13 +1,15 @@
 package intbyte4.learnsmate.campaign.batch;
 
 import intbyte4.learnsmate.issue_coupon.domain.IssueCoupon;
-import intbyte4.learnsmate.issue_coupon.repository.IssueCouponRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,20 +18,44 @@ import java.util.List;
 @Slf4j
 public class CampaignIssueCouponWriter implements ItemWriter<IssueCoupon> {
 
-    private final IssueCouponRepository issueCouponRepository;
+    private final JdbcTemplate jdbcTemplate;
 
     @Override
     public void write(Chunk<? extends IssueCoupon> chunk) throws Exception {
-        long startTime = System.currentTimeMillis(); // 시작 시간 기록
+        List<IssueCoupon> coupons = new ArrayList<>(chunk.getItems());
 
-        List<IssueCoupon> issueCoupons = new ArrayList<>();
-        for (IssueCoupon issueCoupon : chunk) {
-            IssueCoupon newIssueCoupon = IssueCoupon.createIssueCoupon(issueCoupon.getCoupon(), issueCoupon.getStudent());
-            issueCoupons.add(newIssueCoupon);
-        }
-        issueCouponRepository.saveAll(issueCoupons);
+        String sql = """
+            INSERT INTO issue_coupon (
+                coupon_issuance_code,
+                coupon_issue_date,
+                coupon_use_status,
+                coupon_use_date,
+                student_code,
+                coupon_code
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+        """;
 
-        long endTime = System.currentTimeMillis(); // 종료 시간 기록
-        log.info("Writer 데이터 쓰기 완료: {}ms, 처리된 데이터 수: {}", endTime - startTime, issueCoupons.size());
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(java.sql.PreparedStatement ps, int i) throws SQLException {
+                IssueCoupon ic = coupons.get(i);
+                ps.setString(1, ic.getCouponIssuanceCode());
+                ps.setObject(2, ic.getCouponIssueDate());
+                ps.setBoolean(3, ic.getCouponUseStatus());
+                if (ic.getCouponUseDate() != null) {
+                    ps.setObject(4, ic.getCouponUseDate());
+                } else {
+                    ps.setNull(4, java.sql.Types.TIMESTAMP);
+                }
+                ps.setLong(5, ic.getStudent().getMemberCode());
+                ps.setLong(6, ic.getCoupon().getCouponCode());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return coupons.size();
+            }
+        });
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/batch/listener/JobPerformanceListener.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/batch/listener/JobPerformanceListener.java
@@ -1,25 +1,46 @@
 package intbyte4.learnsmate.campaign.batch.listener;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class JobPerformanceListener implements JobExecutionListener {
+
+    private final MeterRegistry meterRegistry;
 
     private long startTime;
 
     @Override
     public void beforeJob(JobExecution jobExecution) {
-        startTime = System.currentTimeMillis();
-        System.out.println("=== Job 시작 ===");
+        startTime = System.nanoTime();
+        log.info("Job [{}] 시작", jobExecution.getJobInstance().getJobName());
     }
 
     @Override
     public void afterJob(JobExecution jobExecution) {
-        long endTime = System.currentTimeMillis();
+        long endTime = System.nanoTime();
         long duration = endTime - startTime;
-        System.out.println("=== Job 종료 ===");
-        System.out.println("Job 실행 시간: " + duration + "ms");
+
+        String caseType = jobExecution.getJobParameters().getString("case", "unknown");
+
+        Timer.builder("campaign_job_duration_seconds")
+                .description("Duration of campaign batch job")
+                .tag("case", caseType)
+                .register(meterRegistry)
+                .record(duration, TimeUnit.NANOSECONDS);
+
+        log.info("Job [{}] 종료. 케이스: [{}], 소요 시간: {} ms",
+                jobExecution.getJobInstance().getJobName(),
+                caseType,
+                TimeUnit.NANOSECONDS.toMillis(duration));
     }
 }

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/controller/CampaignController.java
@@ -33,7 +33,6 @@ public class CampaignController {
     @PostMapping("/register")
     public ResponseEntity<ResponseRegisterCampaignVO> createCampaign
             (@RequestBody RequestRegisterCampaignVO requestCampaign) {
-        log.info("바디 내용은?: {}", requestCampaign.toString());
         List<MemberDTO> studentDTOList = requestCampaign.getStudentList().stream()
                 .map(memberMapper::fromRequestFindCampaignStudentVOToMemberDTO)
                 .toList();
@@ -42,7 +41,6 @@ public class CampaignController {
                 .map(couponMapper::fromRequestFindCampaignCouponVOToCouponDTO)
                 .toList();
 
-        log.info("등록입니다.: {}{}", studentDTOList.toString(), couponDTOList.toString());
         CampaignDTO campaignDTO = campaignService.registerCampaign(campaignMapper
                 .fromRegisterRequestVOtoDTO(requestCampaign)
                 , studentDTOList

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/campaign/service/CampaignServiceImpl.java
@@ -37,7 +37,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -68,7 +67,9 @@ public class CampaignServiceImpl implements CampaignService {
                                         List<CouponDTO> requestCouponList) {
         // 캠페인 기본 정보 설정
         Campaign campaign = createCampaign(requestCampaign);
-        Campaign savedCampaign = campaignRepository.save(campaign);
+        // 캠페인 Repo에 save
+        Campaign savedCampaign = campaignRepository.saveAndFlush(campaign);
+        // DTO로 변환
         CampaignDTO savedCampaignDTO = campaignMapper.toDTO(savedCampaign);
 
         // 학생과 쿠폰 정보 등록
@@ -142,19 +143,26 @@ public class CampaignServiceImpl implements CampaignService {
                     .map(campaignCoupon -> couponService.findCouponDTOByCouponCode(campaignCoupon.getCouponCode()))
                     .toList();
 
+            // ItemReader에 학생, 쿠폰 pairs 전달
             couponMemberReader.setStudentCouponPairs(students, coupons);
 
             if (students.isEmpty() || coupons.isEmpty()) {
                 throw new IllegalArgumentException("No students or coupons found for campaign: " + campaign.getCampaignCode());
             }
-
+            // JobInstance 생성
             JobParameters jobParameters = new JobParametersBuilder()
                     .addLong("campaignCode", campaign.getCampaignCode())
                     .addDate("scheduledTime", Date.from(campaign.getCampaignSendDate().atZone(ZoneId.of("Asia/Seoul")).toInstant()))
+                    .addString("case", "bulk-insert")  // 실험 케이스명: sequencial-save-all, parallel-save-all, bulk-insert
                     .toJobParameters();
+
             log.info("Executing campaign {}", campaign.getCampaignTitle());
+
+            // JobInstance 한번의 시행 시도를 나타냄
+            // JobLauncher Job, JobParameters를 받아 실행하는 역할
             JobExecution jobExecution = jobLauncher.run(campaignJob, jobParameters);
 
+            // BatchStatus가 COMPLETED면 캠페인 발송 후 발송 상태 변경
             if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
                 sendNotifications(campaign);
                 updateCampaignSendFlag(campaign.getCampaignCode());

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/BatchConfig.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/common/config/BatchConfig.java
@@ -58,7 +58,6 @@ public class BatchConfig {
                 .processor(processor)
                 .writer(writer)
                 .taskExecutor(taskExecutor) // TaskExecutor 적용
-                .listener(stepPerformanceListener)
                 .build();
     }
 
@@ -66,7 +65,7 @@ public class BatchConfig {
     public Job campaignJob(Step couponProcessingStep, JobPerformanceListener jobPerformanceListener) {
         return new JobBuilder("campaignJob", jobRepository)
                 .start(couponProcessingStep)
-                .listener(jobPerformanceListener) // 리스너 적용
+                .listener(jobPerformanceListener)
                 .build();
     }
 

--- a/LearnsMate/src/main/java/intbyte4/learnsmate/security/WebSecurity.java
+++ b/LearnsMate/src/main/java/intbyte4/learnsmate/security/WebSecurity.java
@@ -12,6 +12,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -23,7 +24,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 @Configuration
 @EnableWebSecurity
@@ -46,7 +46,10 @@ public class WebSecurity {
         this.refreshTokenService = refreshTokenService;
     }
 
-
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers("/actuator/**");
+    }
     /* 인가(Authorization)용 메소드 */
     @Bean
     protected SecurityFilterChain configure(HttpSecurity http) throws Exception {
@@ -66,6 +69,7 @@ public class WebSecurity {
         // HttpSecurity 설정
         http.authorizeHttpRequests((authz) ->
                         authz
+                                .requestMatchers(new AntPathRequestMatcher("/actuator/**")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/actuator/health")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/error")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/swagger-ui/index.html", "GET")).permitAll()


### PR DESCRIPTION
- 제목 : feat(#4 ):IssueCoupon 대량 발급시 발생하는 속도 저하 문제 개선


## 🔘Part
- [x] BE
- [ ] FE

  <br/>

## 🔎 작업 내용

기존 순차 처리, `JPA saveAll()`을 사용하여 쿠폰을 발급하던 로직을 병렬 처리, `JdbcTemplate.batchUpdate()`로 수정하였습니다.
- 순차 처리, `JPA saveAll()`을 사용했을 경우 -> **약 4.8초**
![image](https://github.com/user-attachments/assets/e6baeb89-b26b-4888-b6f7-a13ecd8a11ab)
- 병렬 처리, `JPA saveAll()`을 사용했을 경우 -> **약 2.0초**
![image](https://github.com/user-attachments/assets/97c2b265-c9b1-4620-9c35-c996807536cd)
- 병렬 처리,`JdbcTemplate.batchUpdate()`를 사용했을 경우 -> **약 0.1초**
![image](https://github.com/user-attachments/assets/48132214-d64a-40ba-8d44-70d0a901f474)

  <br/>

## 🔧 앞으로의 과제

- 프론트엔드 페이지네이션 오류 해결

  <br/>
